### PR TITLE
Downgrading to .NET Standard 2.0

### DIFF
--- a/NScumm.Audio.Players/NScumm.Audio.Players.csproj
+++ b/NScumm.Audio.Players/NScumm.Audio.Players.csproj
@@ -1,11 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackOnBuild>true</PackOnBuild>
     <PackageVersion>1.0</PackageVersion>
     <Authors>scemino</Authors>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\NScumm.Audio\NScumm.Audio.csproj" />

--- a/NScumm.Audio/NScumm.Audio.csproj
+++ b/NScumm.Audio/NScumm.Audio.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackOnBuild>true</PackOnBuild>
     <PackageVersion>1.0</PackageVersion>
     <Authors>scemino</Authors>


### PR DESCRIPTION
I found this downgrade to be necessary for compatibility with Godot Engine v3.2.2.stable.mono.official which uses .NET Framework 4.7.

If I try to build using .NET Standard 2.1 then that causes incompatibility errors.

I believe doing it this way maximizes forwards compatibility across all of .NET but I'm not an expert on these things so I could be wrong.